### PR TITLE
Relaxed version constraints of the FSharp.HotChocolate project

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 Release notes
 ==============
 
+### Unreleased
+
+- Relaxed version requirements to support F# 8 and HotChocolate 13
+
 ### 0.1.4 (2024-09-24)
 
 - Now supports F# unions as GraphQL union types

--- a/src/FSharp.HotChocolate.Tests.CSharpLib/FSharp.HotChocolate.Tests.CSharpLib.csproj
+++ b/src/FSharp.HotChocolate.Tests.CSharpLib/FSharp.HotChocolate.Tests.CSharpLib.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HotChocolate" Version="14.0.0-rc.2" />
+    <PackageReference Include="HotChocolate" Version="13.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FSharp.HotChocolate.Tests.FSharpLib/FSharp.HotChocolate.Tests.FSharpLib.fsproj
+++ b/src/FSharp.HotChocolate.Tests.FSharpLib/FSharp.HotChocolate.Tests.FSharpLib.fsproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="8.0.400" />
+    <PackageReference Update="FSharp.Core" Version="8.*" />
   </ItemGroup>
 
 </Project>

--- a/src/FSharp.HotChocolate.Tests.FSharpLib2/FSharp.HotChocolate.Tests.FSharpLib2.fsproj
+++ b/src/FSharp.HotChocolate.Tests.FSharpLib2/FSharp.HotChocolate.Tests.FSharpLib2.fsproj
@@ -10,7 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="8.0.400" />
+    <PackageReference Update="FSharp.Core" Version="8.*" />
+    <PackageReference Remove="DotNet.ReproducibleBuilds" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FSharp.HotChocolate.Tests/Async.fs
+++ b/src/FSharp.HotChocolate.Tests/Async.fs
@@ -67,7 +67,7 @@ type Query() =
 
 let builder =
     ServiceCollection()
-        .AddGraphQLServer(disableCostAnalyzer = true)
+        .AddGraphQLServer()
         .AddQueryType<Query>()
         .AddFSharpSupport()
         .AddGlobalObjectIdentification()

--- a/src/FSharp.HotChocolate.Tests/FSharp.HotChocolate.Tests.fsproj
+++ b/src/FSharp.HotChocolate.Tests/FSharp.HotChocolate.Tests.fsproj
@@ -27,7 +27,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="FSharp.Core" Version="8.0.400" />
+    <PackageReference Update="FSharp.Core" Version="8.*" />
+    <PackageReference Remove="DotNet.ReproducibleBuilds" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FSharp.HotChocolate.Tests/FSharpCollectionsInput.fs
+++ b/src/FSharp.HotChocolate.Tests/FSharpCollectionsInput.fs
@@ -90,7 +90,7 @@ type Query() =
 
 let builder =
     ServiceCollection()
-        .AddGraphQLServer(disableCostAnalyzer = true)
+        .AddGraphQLServer()
         .AddQueryType<Query>()
         .AddFSharpSupport()
 

--- a/src/FSharp.HotChocolate.Tests/Nullability.fs
+++ b/src/FSharp.HotChocolate.Tests/Nullability.fs
@@ -478,7 +478,7 @@ type Query() =
 
 let builder =
     ServiceCollection()
-        .AddGraphQLServer(disableCostAnalyzer = true)
+        .AddGraphQLServer()
         .AddQueryType<Query>()
         .AddFSharpSupport()
         .AddTypeConverter<Uri, string>(string<Uri>)

--- a/src/FSharp.HotChocolate.Tests/Nullability_GlobalIdentification.fs
+++ b/src/FSharp.HotChocolate.Tests/Nullability_GlobalIdentification.fs
@@ -101,7 +101,7 @@ type Query() =
 
 let builder =
     ServiceCollection()
-        .AddGraphQLServer(disableCostAnalyzer = true)
+        .AddGraphQLServer()
         .AddQueryType<Query>()
         .AddFSharpSupport()
         .AddGlobalObjectIdentification()

--- a/src/FSharp.HotChocolate.Tests/UnionsAsUnions.fs
+++ b/src/FSharp.HotChocolate.Tests/UnionsAsUnions.fs
@@ -87,7 +87,7 @@ type Query() =
 
 let builder =
     ServiceCollection()
-        .AddGraphQLServer(disableCostAnalyzer = true)
+        .AddGraphQLServer()
         .AddQueryType<Query>()
         .AddFSharpSupport()
         .AddType<ADescriptor>()

--- a/src/FSharp.HotChocolate/FSharp.HotChocolate.fsproj
+++ b/src/FSharp.HotChocolate/FSharp.HotChocolate.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.1.4</Version>
+    <Version>0.1.5</Version>
     <Authors>Christer van der Meeren</Authors>
     <Description>Support for F# types and nullability in HotChocolate.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -22,10 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HotChocolate.AspNetCore" Version="14.0.0-rc.2" />
-    <PackageReference Include="HotChocolate.Types.CursorPagination" Version="14.0.0-rc.2" />
-    <PackageReference Include="HotChocolate.Types.FSharp" Version="14.0.0-rc.2" />
-    <PackageReference Update="FSharp.Core" Version="8.0.100" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="13.*" />
+    <PackageReference Include="HotChocolate.Types.CursorPagination" Version="13.*" />
+    <PackageReference Include="HotChocolate.Types.FSharp" Version="13.*" />
+    <PackageReference Update="FSharp.Core" Version="8.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I wanted to start using this project so I can find bugs and missing features, however my current project is using Hot Chocolate 13 so dependency resolution failed. I have downgraded the requirements to Hot Chocolate 13, so that the library can be used while using the latest stable major version. Same for the F# Core version. 

I had to remove the cost analyzer paramater from several of the tests, as this didn't seem to be present in HotChocolate 13.