### PR TITLE
Added special handling for single-case discriminated unions

### DIFF
--- a/src/FSharp.HotChocolate.Tests/FSharp.HotChocolate.Tests.fsproj
+++ b/src/FSharp.HotChocolate.Tests/FSharp.HotChocolate.Tests.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="FSharpCollectionsInput.fs" />
     <Compile Include="UnionsAsEnums.fs" />
     <Compile Include="UnionsAsUnions.fs" />
+    <Compile Include="SingleCaseUnions.fs" />
     <Compile Include="Nullability.fs" />
     <Compile Include="Nullability_GlobalIdentification.fs" />
     <Compile Include="Async.fs" />
@@ -36,6 +37,15 @@
     <ProjectReference Include="..\FSharp.HotChocolate.Tests.CSharpLib\FSharp.HotChocolate.Tests.CSharpLib.csproj" />
     <ProjectReference Include="..\FSharp.HotChocolate.Tests.FSharpLib2\FSharp.HotChocolate.Tests.FSharpLib2.fsproj" />
     <ProjectReference Include="..\FSharp.HotChocolate\FSharp.HotChocolate.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Snapshots\SingleCaseUnions.Schema is expected.verified.graphql">
+      <ParentFile>SingleCaseUnions</ParentFile>
+    </None>
+    <None Update="Snapshots\SingleCaseUnions.Can get A.verified.json">
+      <ParentFile>SingleCaseUnions</ParentFile>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/FSharp.HotChocolate.Tests/SingleCaseUnions.fs
+++ b/src/FSharp.HotChocolate.Tests/SingleCaseUnions.fs
@@ -13,9 +13,7 @@ open Xunit
 configureVerify
 
 
-type MySingleCaseUnion = MySingleCaseUnion of string
-type MyPrivateSingleCaseUnion = private MyPrivateSingleCaseUnion of string
-
+type MySingleCaseUnion = private MySingleCaseUnion of string
 
 type A = {
     X: MySingleCaseUnion

--- a/src/FSharp.HotChocolate.Tests/SingleCaseUnions.fs
+++ b/src/FSharp.HotChocolate.Tests/SingleCaseUnions.fs
@@ -1,0 +1,208 @@
+module SingleCaseUnions
+
+
+open System.Diagnostics.CodeAnalysis
+open System.Threading.Tasks
+open HotChocolate.Execution
+open Microsoft.Extensions.DependencyInjection
+open HotChocolate
+open VerifyXunit
+open Xunit
+
+
+configureVerify
+
+
+type MySingleCaseUnion = MySingleCaseUnion of string
+type MyPrivateSingleCaseUnion = private MyPrivateSingleCaseUnion of string
+
+
+type A = {
+    X: MySingleCaseUnion
+    Y: MySingleCaseUnion option
+    Z: MySingleCaseUnion array
+}
+
+
+type Query() =
+
+    member _.Union = MySingleCaseUnion "Hello world!"
+
+    member _.A = {
+        X = MySingleCaseUnion "Hello world!"
+        Y = Some(MySingleCaseUnion "Hello world!")
+        Z = [| MySingleCaseUnion "Hello world!" |]
+    }
+
+    member _.OptionOfMyUnion: MySingleCaseUnion option = None
+
+    member _.ArrayOfMyUnion = [| MySingleCaseUnion "Hello world!" |]
+
+    member _.ArrayOfOptionOfMyUnion: MySingleCaseUnion option array = [| None |]
+
+    member _.TaskOfMyUnion = Task.FromResult(MySingleCaseUnion "Hello world!")
+
+    member _.ValueTaskOfMyUnion = ValueTask.FromResult(MySingleCaseUnion "Hello world!")
+
+    member _.AsyncOfMyUnion = async.Return(MySingleCaseUnion "Hello world!")
+
+    member _.AsyncOfOptionOfMyUnion: Async<MySingleCaseUnion option> = async.Return(None)
+
+    member _.AsyncOfArrayOfMyUnion = async.Return [| MySingleCaseUnion "Hello world!" |]
+
+    member _.AsyncOfArrayOfOptionOfMyUnion =
+        async.Return [| Some(MySingleCaseUnion "Hello world!") |]
+
+    member _.TaskOfOptionOfArrayOfOptionOfMyUnion =
+        Task.FromResult(Some([| Some(MySingleCaseUnion "Hello world!") |]))
+
+    member _.AsyncOfOptionOfArrayOfOptionOfMyUnion: Async<MySingleCaseUnion option array option> =
+        async.Return(Some([| None |]))
+
+// member _.MyPrivateUnion = MyPrivateSingleCaseUnion "Hello world!"
+
+let builder =
+    ServiceCollection()
+        .AddGraphQLServer(disableCostAnalyzer = true)
+        .AddFSharpSupport()
+        .AddQueryType<Query>()
+
+
+[<Fact>]
+let ``Schema is expected`` () =
+    task {
+        let! schema = builder.BuildSchemaAsync()
+        let! _ = Verifier.Verify(schema.ToString(), extension = "graphql")
+        ()
+    }
+
+
+let private verifyQuery ([<StringSyntax("graphql")>] query: string) =
+    task {
+        let! result = builder.ExecuteRequestAsync(query)
+        let! _ = Verifier.Verify(result.ToJson(), extension = "json")
+        ()
+    }
+
+
+[<Fact>]
+let ``Can get single case union`` () =
+    verifyQuery
+        "
+query {
+  union
+}
+"
+
+[<Fact>]
+let ``Can get A`` () =
+    verifyQuery
+        "
+query {
+  a {
+    x
+    y
+    z
+  }
+}
+"
+
+
+[<Fact>]
+let ``Can get option of union`` () =
+    verifyQuery
+        "
+query {
+  optionOfMyUnion
+}
+"
+
+
+[<Fact>]
+let ``Can get arrayOfMyUnion`` () =
+    verifyQuery
+        "
+query {
+  arrayOfMyUnion
+}
+"
+
+
+[<Fact>]
+let ``Can get arrayOfOptionOfMyUnion`` () =
+    verifyQuery
+        "
+query {
+  arrayOfOptionOfMyUnion
+}
+"
+
+
+[<Fact>]
+let ``Can get taskOfMyUnion`` () =
+    verifyQuery
+        "
+query {
+  taskOfMyUnion
+}
+"
+
+
+[<Fact>]
+let ``Can get valueTaskOfMyUnion`` () =
+    verifyQuery
+        "
+query {
+  valueTaskOfMyUnion
+}
+"
+
+
+[<Fact>]
+let ``Can get asyncOfMyUnion`` () =
+    verifyQuery
+        "
+query {
+  asyncOfMyUnion
+}
+"
+
+
+[<Fact>]
+let ``Can get asyncOfOptionOfMyUnion`` () =
+    verifyQuery
+        "
+query {
+  asyncOfOptionOfMyUnion
+}
+"
+
+
+[<Fact>]
+let ``Can get asyncOfArrayOfMyUnion`` () =
+    verifyQuery
+        "
+query {
+  asyncOfArrayOfMyUnion
+}
+"
+
+
+[<Fact>]
+let ``Can get asyncOfArrayOfOptionOfMyUnion`` () =
+    verifyQuery
+        "
+query {
+  asyncOfArrayOfOptionOfMyUnion
+}
+"
+
+
+[<Fact>]
+let ``Can get asyncOfOptionOfArrayOfOptionOfMyUnion`` () =
+    verifyQuery
+        "
+query {
+  asyncOfOptionOfArrayOfOptionOfMyUnion
+}
+"

--- a/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get A.verified.json
+++ b/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get A.verified.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "a": {
+      "x": "Hello world!",
+      "y": "Hello world!",
+      "z": [
+        "Hello world!"
+      ]
+    }
+  }
+}

--- a/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get arrayOfMyUnion.verified.json
+++ b/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get arrayOfMyUnion.verified.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "arrayOfMyUnion": [
+      "Hello world!"
+    ]
+  }
+}

--- a/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get arrayOfOptionOfMyUnion.verified.json
+++ b/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get arrayOfOptionOfMyUnion.verified.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "arrayOfOptionOfMyUnion": [
+      null
+    ]
+  }
+}

--- a/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get asyncOfArrayOfMyUnion.verified.json
+++ b/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get asyncOfArrayOfMyUnion.verified.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "asyncOfArrayOfMyUnion": [
+      "Hello world!"
+    ]
+  }
+}

--- a/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get asyncOfArrayOfOptionOfMyUnion.verified.json
+++ b/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get asyncOfArrayOfOptionOfMyUnion.verified.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "asyncOfArrayOfOptionOfMyUnion": [
+      "Hello world!"
+    ]
+  }
+}

--- a/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get asyncOfMyUnion.verified.json
+++ b/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get asyncOfMyUnion.verified.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "asyncOfMyUnion": "Hello world!"
+  }
+}

--- a/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get asyncOfOptionOfArrayOfOptionOfMyUnion.verified.json
+++ b/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get asyncOfOptionOfArrayOfOptionOfMyUnion.verified.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "asyncOfOptionOfArrayOfOptionOfMyUnion": [
+      null
+    ]
+  }
+}

--- a/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get asyncOfOptionOfMyUnion.verified.json
+++ b/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get asyncOfOptionOfMyUnion.verified.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "asyncOfOptionOfMyUnion": null
+  }
+}

--- a/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get option of union.verified.json
+++ b/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get option of union.verified.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "optionOfMyUnion": null
+  }
+}

--- a/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get single case union.verified.json
+++ b/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get single case union.verified.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "union": "Hello world!"
+  }
+}

--- a/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get taskOfMyUnion.verified.json
+++ b/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get taskOfMyUnion.verified.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "taskOfMyUnion": "Hello world!"
+  }
+}

--- a/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get valueTaskOfMyUnion.verified.json
+++ b/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Can get valueTaskOfMyUnion.verified.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "valueTaskOfMyUnion": "Hello world!"
+  }
+}

--- a/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Schema is expected.verified.graphql
+++ b/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Schema is expected.verified.graphql
@@ -8,13 +8,6 @@ type A {
   z: [String!]!
 }
 
-type MySingleCaseUnion {
-  get_Item: String!
-  get_Tag: Int!
-  tag: Int!
-  item: String!
-}
-
 type Query {
   union: String!
   a: A!

--- a/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Schema is expected.verified.graphql
+++ b/src/FSharp.HotChocolate.Tests/Snapshots/SingleCaseUnions.Schema is expected.verified.graphql
@@ -1,0 +1,32 @@
+schema {
+  query: Query
+}
+
+type A {
+  x: String!
+  y: String
+  z: [String!]!
+}
+
+type MySingleCaseUnion {
+  get_Item: String!
+  get_Tag: Int!
+  tag: Int!
+  item: String!
+}
+
+type Query {
+  union: String!
+  a: A!
+  optionOfMyUnion: String
+  arrayOfMyUnion: [String!]!
+  arrayOfOptionOfMyUnion: [String]!
+  taskOfMyUnion: String!
+  valueTaskOfMyUnion: String!
+  asyncOfMyUnion: String!
+  asyncOfOptionOfMyUnion: String
+  asyncOfArrayOfMyUnion: [String!]!
+  asyncOfArrayOfOptionOfMyUnion: [String]!
+  taskOfOptionOfArrayOfOptionOfMyUnion: [String]
+  asyncOfOptionOfArrayOfOptionOfMyUnion: [String]
+}

--- a/src/FSharp.HotChocolate.Tests/Snapshots/UnionsAsEnums.Schema is expected.verified.graphql
+++ b/src/FSharp.HotChocolate.Tests/Snapshots/UnionsAsEnums.Schema is expected.verified.graphql
@@ -15,6 +15,8 @@ type Query {
   asyncOfArrayOfOptionOfMyUnion: [MyUnion]!
   taskOfOptionOfArrayOfOptionOfMyUnion: [MyUnion]
   asyncOfOptionOfArrayOfOptionOfMyUnion: [MyUnion]
+  referenceEnum: ReferenceEnum!
+  myUnion2: MyUnion2OverriddenName!
 }
 
 enum MyUnion {

--- a/src/FSharp.HotChocolate.Tests/UnionsAsEnums.fs
+++ b/src/FSharp.HotChocolate.Tests/UnionsAsEnums.fs
@@ -81,6 +81,10 @@ type Query() =
 
     member _.AsyncOfOptionOfArrayOfOptionOfMyUnion = async.Return(Some([| Some A |]))
 
+    member _.ReferenceEnum: ReferenceEnum = ReferenceEnum.A
+
+    member _.MyUnion2: MyUnion2 = MyUnion2.A
+
 
 let builder =
     ServiceCollection()

--- a/src/FSharp.HotChocolate/FSharp.HotChocolate.fsproj
+++ b/src/FSharp.HotChocolate/FSharp.HotChocolate.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="FSharpCollectionsInput.fs" />
     <Compile Include="UnionsAsEnums.fs" />
     <Compile Include="UnionsAsUnions.fs" />
+    <Compile Include="SingleCaseUnions.fs" />
     <Compile Include="Nullability.fs" />
     <Compile Include="Async.fs" />
     <Compile Include="IRequestExecutorBuilderExtensions.fs" />

--- a/src/FSharp.HotChocolate/IRequestExecutorBuilderExtensions.fs
+++ b/src/FSharp.HotChocolate/IRequestExecutorBuilderExtensions.fs
@@ -15,6 +15,7 @@ type IRequestExecutorBuilder with
             .AddTypeConverter<OptionTypeConverter>()
             .AddTypeConverter<ListTypeConverter>()
             .AddTypeConverter<SetTypeConverter>()
+            .TryAddTypeInterceptor<FSharpSingleCaseUnionInterceptor>()
             .TryAddTypeInterceptor<FSharpUnionAsUnionInterceptor>()
             .TryAddTypeInterceptor<FSharpNullabilityTypeInterceptor>()
             .TryAddTypeInterceptor<FSharpAsyncTypeInterceptor>()

--- a/src/FSharp.HotChocolate/IRequestExecutorBuilderExtensions.fs
+++ b/src/FSharp.HotChocolate/IRequestExecutorBuilderExtensions.fs
@@ -12,9 +12,11 @@ type IRequestExecutorBuilder with
     /// parameters.
     member this.AddFSharpSupport() : IRequestExecutorBuilder =
         this
+            .ModifyOptions(fun options -> options.RemoveUnreachableTypes <- true)
             .AddTypeConverter<OptionTypeConverter>()
             .AddTypeConverter<ListTypeConverter>()
             .AddTypeConverter<SetTypeConverter>()
+            .AddTypeConverter<SingleCaseUnionConverter>()
             .TryAddTypeInterceptor<FSharpSingleCaseUnionInterceptor>()
             .TryAddTypeInterceptor<FSharpUnionAsUnionInterceptor>()
             .TryAddTypeInterceptor<FSharpNullabilityTypeInterceptor>()

--- a/src/FSharp.HotChocolate/Nullability.fs
+++ b/src/FSharp.HotChocolate/Nullability.fs
@@ -25,8 +25,6 @@ type SkipFSharpNullabilityAttribute() =
 
 [<AutoOpen>]
 module private NullabilityHelpers =
-
-
     let useFSharpNullabilityForMember (mi: MemberInfo) =
         if isNull mi then
             false

--- a/src/FSharp.HotChocolate/Reflection.fs
+++ b/src/FSharp.HotChocolate/Reflection.fs
@@ -570,7 +570,7 @@ let makeSingleCaseUnionValue x =
     if isNull x then
         null
     else
-        getCachedSomeConstructor (x.GetType()) x
+        getCachedSingleCaseUnionCtor (x.GetType()) x
 
 
 let mapSingleCaseUnionValue f x =

--- a/src/FSharp.HotChocolate/SingleCaseUnions.fs
+++ b/src/FSharp.HotChocolate/SingleCaseUnions.fs
@@ -1,0 +1,62 @@
+namespace HotChocolate
+
+open System
+open System.Reflection
+open HotChocolate.Configuration
+open HotChocolate.Internal
+open HotChocolate.Types.Descriptors
+open HotChocolate.Types.Descriptors.Definitions
+open HotChocolate.Utilities
+
+[<AttributeUsage(AttributeTargets.Assembly
+                 ||| AttributeTargets.Class
+                 ||| AttributeTargets.Field
+                 ||| AttributeTargets.Method
+                 ||| AttributeTargets.Parameter
+                 ||| AttributeTargets.Property
+                 ||| AttributeTargets.Struct)>]
+[<AllowNullLiteral>]
+type SkipFSharpSingleCaseUnionUnwrappingAttribute() =
+    inherit Attribute()
+
+/// A type interceptor for handling F# single-case union types within
+/// the HotChocolate GraphQL framework. This interceptor checks if a
+/// field's type is a single-case union and adjusts the field's type
+/// definition to use the inner type of the union case, enabling proper
+/// type conversion and schema generation for these F# types.
+type FSharpSingleCaseUnionInterceptor() =
+    inherit TypeInterceptor()
+
+    let doesNotHaveSkipAttr (mi: MemberInfo) (ty: Type) =
+        let noAttrInMember =
+            mi.GetCustomAttribute<SkipFSharpSingleCaseUnionUnwrappingAttribute>() |> isNull
+
+        let noAttrInType =
+            ty.GetCustomAttribute<SkipFSharpSingleCaseUnionUnwrappingAttribute>() |> isNull
+
+        let noAttrInAssembly =
+            ty.Assembly.GetCustomAttribute<SkipFSharpSingleCaseUnionUnwrappingAttribute>()
+            |> isNull
+
+        noAttrInType || noAttrInAssembly || noAttrInMember
+
+    override this.OnAfterInitialize(discoveryContext, definition) =
+        let typeInspector = discoveryContext.TypeInspector
+
+        match definition with
+        | :? ObjectTypeDefinition as objectDef ->
+            objectDef.Fields
+            |> Seq.iter (fun fieldDef ->
+                match fieldDef.Type with
+                | :? ExtendedTypeReference as exTy ->
+                    exTy.Type.Type
+                    |> Reflection.unwrapPossiblyNestedSingleCaseUnionType
+                    |> Option.filter (doesNotHaveSkipAttr fieldDef.Member)
+                    |> Option.map typeInspector.GetTypeRef
+                    |> Option.iter (fun ty ->
+                        fieldDef.Type <- ty
+                        ()
+                    )
+                | _ -> ()
+            )
+        | _ -> ()


### PR DESCRIPTION
Single case discriminated unions should not be treated as regular DUs, instead they are usually used to model constrained types within a domain. This PR implements automatic unwrapping of these values into their field types in the GraphQL schema. This allows the direct mapping of wrapped DUs coming from a source such as Marten (that use IQueryable) to be directly exposed as part of the GraphQL schema. 

The unwrapping support is only enabled for output object types, as generally input types should be validated before being wrapped.